### PR TITLE
Change default key binding on MacOS to ⌥ + ^ (Option + CTRL key)

### DIFF
--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -173,6 +173,10 @@
    </extension>
    <extension
          point="org.eclipse.ui.bindings">
+      <sequenceModifier
+            find="M3"
+            replace="M3+M4"
+            platforms="cocoa,carbon" />
       <key
             commandId="de.anbos.eclipse.easyshell.plugin.commands.open"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"


### PR DESCRIPTION
## Issue:
#200

## Proposed changes
This change fixes issue #200 as proposed: change the default key binding on MacOS generally to `⌥` + `^` (Option + CTRL key); e.g., `⌥` + `^` + `E O` for opening a terminal.
