### PR TITLE
Update links to HTTPS

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,13 +6,13 @@ This Eclipse plugin allows to open a shell window or file manager from the popup
 
 Installation:
 -------------
-Eclipse Markeplace: http://marketplace.eclipse.org/content/easyshell
+Eclipse Markeplace: https://marketplace.eclipse.org/content/easyshell
 
-<a href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=974" class="drag" title="Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client"><img class="img-responsive" src="https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.png" alt="Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client" /></a>
+<a href="https://marketplace.eclipse.org/marketplace-client-intro?mpc_install=974" class="drag" title="Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client"><img class="img-responsive" src="https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.png" alt="Drag to your running Eclipse* workspace. *Requires Eclipse Marketplace Client" /></a>
 
 OR
 
-Use update site: http://anb0s.github.io/EasyShell
+Use update site: https://anb0s.github.io/EasyShell
 
 OR
 
@@ -76,20 +76,20 @@ The following platform, shell combinations and tools are supported as selections
   - PowerShell (also as admin)
   - Windows Terminal
   - Bash
-    - Cygwin: http://cygwin.com
+    - Cygwin: https://cygwin.com
     - Git for Windows 1.x/2.x: https://git-for-windows.github.io
-    - Msys2 / MinGW32 / MinGW64: http://www.msys2.org
+    - Msys2 / MinGW32 / MinGW64: https://www.msys2.org
   - Console:
     - Console2: https://sourceforge.net/projects/console
     - ConsoleZ: https://github.com/cbucher/console
   - ConEmu: https://code.google.com/p/conemu-maximus5
   - Cmder: https://github.com/cmderdev/cmder
-  - PowerCmd: http://www.powercmd.com
+  - PowerCmd: https://www.powercmd.com
 - File Browsers
   - Explorer
-  - TotalCommander: http://www.ghisler.com
-  - DoubleCommander: http://doublecmd.sourceforge.net
-  - Q-Dir (Quad Explorer): http://www.softwareok.de/?seite=Freeware/Q-Dir
+  - TotalCommander: https://www.ghisler.com
+  - DoubleCommander: https://doublecmd.sourceforge.net
+  - Q-Dir (Quad Explorer): https://www.softwareok.de/?seite=Freeware/Q-Dir
 
 **Linux:**
 - Terminals
@@ -114,9 +114,9 @@ The following platform, shell combinations and tools are supported as selections
   - Thunar
   - Caja
   - Krusader
-  - DoubleCommander: http://doublecmd.sourceforge.net
-  - Midnight Commander: http://midnight-commander.org
-  - Sunflower: http://sunflower-fm.org
+  - DoubleCommander: https://doublecmd.sourceforge.io
+  - Midnight Commander: https://midnight-commander.org
+  - Sunflower: https://sunflower-fm.org
 
 **MAC OS X**
 - Terminals
@@ -206,6 +206,6 @@ The following substitution variables are available for building the menu name:
 - ```${easyshell:command_name}``` = command name
 - ```${easyshell:command_os}``` = command operating system
 
-<a href="http://with-eclipse.github.io/" target="_blank">
-<img alt="with-Eclipse logo" src="http://with-eclipse.github.io/with-eclipse-0.jpg" />
+<a href="https://with-eclipse.github.io/" target="_blank">
+<img alt="with-Eclipse logo" src="https://with-eclipse.github.io/with-eclipse-0.jpg" />
 </a>


### PR DESCRIPTION
Especially the update site and market place URLs should use HTTPS for security reasons.